### PR TITLE
Update style.css for Compatibility with Web AppBuilder 2.7

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,26 +11,26 @@ div.jimu-widget-savesession .jimu-icon {
     margin-right: 5px;
 }
 
-.jimu-icon-load {
-    background-position: -0px -47px;
+.jimu-icon-add {
+    background-position: -0px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load.jimu-state-disabled {
-    background-position: -63px -47px;
+.jimu-icon-add.jimu-state-disabled {
+    background-position: -63px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load.jimu-state-hover {
-    background-position: -21px -47px;
+.jimu-icon-add.jimu-state-hover {
+    background-position: -21px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load:hover {
-    background-position: -21px -47px;
+.jimu-icon-add:hover {
+    background-position: -21px -60px;
     width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
Web AppBuilder 2.7 contains changes in ...\client\stemapp\jimu.js\css sprite files, including sprite.css and sprite.png.  Particularly, jimu-icon-load was changed to jimu-icon-add.  This resulted in a missing load icon in the SaveSession Widget when using web map applications created in Web AppBuilder 2.7.